### PR TITLE
Fix > exception 'InvalidArgumentException' with message '[maxiPago Class] Field 'filterOptions' is invalid. Please see documention for help.' in lib/MaxiPago/XmlBuilder.php:1020

### DIFF
--- a/1.7.x-1.9.x/app/code/community/MaxiPago/Payment/Model/Api.php
+++ b/1.7.x-1.9.x/app/code/community/MaxiPago/Payment/Model/Api.php
@@ -1199,8 +1199,10 @@ class MaxiPago_Payment_Model_Api extends Mage_Core_Model_Abstract
                 $this->getMaxipago()->pullPaymentOrder($data);
             } else {
                 if ($transactionId) {
+                    $paymentTransaction = Mage::getModel('sales/order_payment_transaction')->load($payment->getId(), 'payment_id');
+
                     $data = array(
-                        "transactionID" => $payment->getAdditionalInformation('transaction_id'),
+                        "transactionID" => $paymentTransaction->getTxnId(),
                     );
                 } else {
                     $data = array(

--- a/1.7.x-1.9.x/app/code/community/MaxiPago/Payment/Model/Cron.php
+++ b/1.7.x-1.9.x/app/code/community/MaxiPago/Payment/Model/Cron.php
@@ -66,7 +66,7 @@ class MaxiPago_Payment_Model_Cron
                 /** @var MaxiPago_Payment_Helper_Data $helper */
                 $helper = $this->_getHelper();
 
-                $response = $helper->getApi()->pullReport($order, false, self::CRON_FILE);
+                $response = $helper->getApi()->pullReport($order, true, self::CRON_FILE);
                 if (isset($response['records'])) {
                     $record = isset($response['records'][0]) ? $response['records'][0] : null;
                     if ($record) {


### PR DESCRIPTION
Correção para a exception abaixo:

exception 'InvalidArgumentException' with message '[maxiPago Class] Field 'filterOptions' is invalid. Please see documention for help.' in lib/MaxiPago/XmlBuilder.php:1020
Stack trace:
#0 lib/MaxiPago/RequestBase.php(260): maxiPago_XmlBuilder->setRapiRequest()
#1 lib/MaxiPago/MaxiPago.php(550): maxiPago_RequestBase->processRequest()
#2 app/code/community/MaxiPago/Payment/Model/Api.php(1211): MaxiPago->pullReport(Array)
#3 app/code/community/MaxiPago/Payment/Model/Cron.php(69): MaxiPago_Payment_Model_Api->pullReport(Object(Mage_Sales_Model_Order), false, 'maxipago-cron.l...')
#4 [internal function]: MaxiPago_Payment_Model_Cron->queryPayments(Object(Aoe_Scheduler_Model_Schedule))
#5 app/code/community/Aoe/Scheduler/Model/Observer.php(80): call_user_func_array(Array, Array)
#6 app/code/core/Mage/Core/Model/App.php(1358): Aoe_Scheduler_Model_Observer->dispatch(Object(Varien_Event_Observer))
#7 app/code/core/Mage/Core/Model/App.php(1337): Mage_Core_Model_App->_callObserverMethod(Object(Aoe_Scheduler_Model_Observer), 'dispatch', Object(Varien_Event_Observer))
#8 app/Mage.php(448): Mage_Core_Model_App->dispatchEvent('default', Array)
#9 cron.php(76): Mage::dispatchEvent('default')
#10 {main}